### PR TITLE
Making methods usable without displaying instantly

### DIFF
--- a/Classes/CLIm.php
+++ b/Classes/CLIm.php
@@ -437,9 +437,9 @@ class CLIm
      * @return $this
      * @see \CLIm\Helpers\Style
      */
-    public function style($flags, $add = true)
+    public function style($flags, $add = true, $return = false)
     {
-        return $this->esc($this->style->format($flags, (bool)$add));
+        return $this->esc($this->style->format($flags, (bool)$add), $return);
     }
 
     /**
@@ -447,9 +447,9 @@ class CLIm
      * @param int|string $color
      * @return $this
      */
-    public function color($color)
+    public function color($color, $return = false)
     {
-        return $this->esc($this->colors->format($color));
+        return $this->esc($this->colors->format($color), $return);
     }
 
     /**
@@ -457,18 +457,18 @@ class CLIm
      * @param int|string $color
      * @return $this
      */
-    public function bgColor($color)
+    public function bgColor($color, $return = false)
     {
-        return $this->esc($this->colors->format($color, true));
+        return $this->esc($this->colors->format($color, true), $return);
     }
 
     /**
      * Reset text color and style
      * @return $this
      */
-    public function reset()
+    public function reset($return = false)
     {
-        return $this->esc('0m');
+        return $this->esc('0m', $return);
     }
 
     /**

--- a/Classes/CLIm.php
+++ b/Classes/CLIm.php
@@ -434,6 +434,7 @@ class CLIm
      * Add or remove some rendering flag
      * @param int $flags
      * @param bool $add
+     * @param bool $return
      * @return $this
      * @see \CLIm\Helpers\Style
      */
@@ -445,6 +446,7 @@ class CLIm
     /**
      * Set text color
      * @param int|string $color
+     * @param bool $return
      * @return $this
      */
     public function color($color, $return = false)
@@ -455,6 +457,7 @@ class CLIm
     /**
      * Set background color
      * @param int|string $color
+     * @param bool $return
      * @return $this
      */
     public function bgColor($color, $return = false)
@@ -464,6 +467,7 @@ class CLIm
 
     /**
      * Reset text color and style
+     * @param bool $return
      * @return $this
      */
     public function reset($return = false)


### PR DESCRIPTION
This PR allows to use `::color()`, `::bgColor()`, `::reset()` and `::style()` to manipulate strings before the actual display.
